### PR TITLE
ScanID - Make as an explicit output

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,8 @@ inputs:
 outputs:
   scan-findings:
       description: "A raw JSON report containing all findings from a completed scan."
+  scan-id:
+      description: "The ID of the current scan that was run."
 runs:
   using: node12
   main: dist/index.js

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const INPUT_VULN_QUERY = "vuln-query";
 const INPUT_WAIT_SCAN_COMPLETE = "wait-for-scan-complete";
 const INPUT_SCAN_TIMEOUT_MINS = "scan-timeout-mins";
 const OUTPUT_SCAN_FINDINGS = "scan-findings";
+const OUTPUT_SCAN_ID = "scan-id";
 
 function isInputValid(key, value) {
     if(!value) {
@@ -56,8 +57,9 @@ async function performAction() {
 
     try {
         const scanId = await scanTools.startScan(scanConfigId);
+        core.setOutput(OUTPUT_SCAN_ID, scanId);  
         if (!waitScanComplete) {
-            core.setOutput(OUTPUT_SCAN_FINDINGS, `Scan ID: ${scanId}`);
+            core.setOutput(OUTPUT_SCAN_ID, scanId);
         }
         else {
             const startTimeMillis = new Date().getTime();


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->

Hi all,

I am proposing the following change to have an explicit output for the ScanID. Being able to have the scan id readily available, whether the scan is successful or not, will allow for us to take said scan id to be used against any of the Rapid7 APIs to query for more information that we can bring into our reporting tools (PowerBI, etc.)

## Testing
<!-- Describe how this change was tested -->

Ran a copy of this action against my Rapid7 instance.

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
