### PR TITLE
IAS-10918: Change save-state to GITHUB_STATE

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -657,7 +657,7 @@ exports.group = group;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
+    command_1.issueCommand('GITHUB_STATE', { name }, value);
 }
 exports.saveState = saveState;
 /**


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
Github are deprecating the use of save-state as of 31 May 2023. Convert uses of save state to use GITHUB_STATE instead
<!-- Add JIRA link if applicable -->

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
