### PR TITLE
Use `core.setFailed` when an error occurs to prevent incorrect successful job reporting

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11383,13 +11383,13 @@ async function performAction() {
             return;
         }
     }
-    
+
     core.info(`Scan gating query: ${vulnQuery}`);
     core.info(`Wait for scan complete: ${waitScanComplete}`);
 
-    if(!isInputValid(INPUT_REGION, region) || 
-       !isInputValid(INPUT_API_KEY, apiKey) || 
-       !isInputValid(INPUT_SCAN_CONFIG_ID, scanConfigId)) 
+    if(!isInputValid(INPUT_REGION, region) ||
+       !isInputValid(INPUT_API_KEY, apiKey) ||
+       !isInputValid(INPUT_SCAN_CONFIG_ID, scanConfigId))
     {
         return;
     }
@@ -11419,12 +11419,12 @@ async function performAction() {
         }
     }
     catch(e) {
-        core.error(`An error occurred with the scan: ${e}`);
+        core.setFailed(`An error occurred with the scan: ${e}`);
     }
 }
 
 performAction().catch( (error) => {
-    core.error(`An error occurred during the action ${error}`);
+    core.setFailed(`An error occurred during the action ${error}`);
 });
 })();
 

--- a/index.js
+++ b/index.js
@@ -41,13 +41,13 @@ async function performAction() {
             return;
         }
     }
-    
+
     core.info(`Scan gating query: ${vulnQuery}`);
     core.info(`Wait for scan complete: ${waitScanComplete}`);
 
-    if(!isInputValid(INPUT_REGION, region) || 
-       !isInputValid(INPUT_API_KEY, apiKey) || 
-       !isInputValid(INPUT_SCAN_CONFIG_ID, scanConfigId)) 
+    if(!isInputValid(INPUT_REGION, region) ||
+       !isInputValid(INPUT_API_KEY, apiKey) ||
+       !isInputValid(INPUT_SCAN_CONFIG_ID, scanConfigId))
     {
         return;
     }
@@ -77,10 +77,10 @@ async function performAction() {
         }
     }
     catch(e) {
-        core.error(`An error occurred with the scan: ${e}`);
+        core.setFailed(`An error occurred with the scan: ${e}`);
     }
 }
 
 performAction().catch( (error) => {
-    core.error(`An error occurred during the action ${error}`);
+    core.setFailed(`An error occurred with the scan: ${error}`);
 });


### PR DESCRIPTION

## Description
Current action is incorrectly showing success when an error occurs when setting up the scan. Rather than reporting the error and allowing the job to succeed I believe this should `core.setFailed` to correctly reflect the fact the GitHub action failed.

## Testing
Used my version with a bad scan id and received and error with the same messaging as before

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
